### PR TITLE
Fix Black Hole CO power theme filename resolution bug

### DIFF
--- a/music_player/resources.ts
+++ b/music_player/resources.ts
@@ -260,16 +260,17 @@ function getMusicFilename(coName: string, requestedGameType: GameType, actualGam
 
   // Change CO name to "andy-cop" for file checking in RBC
   // Change to "ally" or "bh" for AW2 and DS
+  let powerThemeName: string; // ADDED: Declare separate variable for power theme name
   if (requestedGameType === GameType.RBC && isCOInRBC) {
-    coName = `${coName}-cop`;
+    powerThemeName = `${coName}-cop`; // CHANGED: Use powerThemeName instead of coName
   } else {
     const powerSuffix = themeType === ThemeType.CO_POWER ? "-co-power" : "-super-co-power";
-    coName = isBlackHoleCO(coName) ? "bh" : "ally";
-    coName += powerSuffix;
+    powerThemeName = isBlackHoleCO(coName) ? "bh" : "ally"; // CHANGED: Use powerThemeName instead of coName
+    powerThemeName += powerSuffix; // CHANGED: Use powerThemeName instead of coName
   }
-  const hasCopIntro = hasIntroTheme(coName, actualGameType);
-  const hasCopPreloop = hasPreloopTheme(coName, actualGameType);
-  return hasCopIntro ? `t-${coName}-intro` : hasCopPreloop ? `t-${coName}-preloop` : `t-${coName}`;
+  const hasCopIntro = hasIntroTheme(powerThemeName, actualGameType); // CHANGED: Use powerThemeName instead of coName
+  const hasCopPreloop = hasPreloopTheme(powerThemeName, actualGameType); // CHANGED: Use powerThemeName instead of coName
+  return hasCopIntro ? `t-${powerThemeName}-intro` : hasCopPreloop ? `t-${powerThemeName}-preloop` : `t-${powerThemeName}`; // CHANGED: Use powerThemeName instead of coName
 }
 
 /**

--- a/music_player/resources.ts
+++ b/music_player/resources.ts
@@ -260,17 +260,17 @@ function getMusicFilename(coName: string, requestedGameType: GameType, actualGam
 
   // Change CO name to "andy-cop" for file checking in RBC
   // Change to "ally" or "bh" for AW2 and DS
-  let powerThemeName: string; // ADDED: Declare separate variable for power theme name
+  let powerThemeName: string;
   if (requestedGameType === GameType.RBC && isCOInRBC) {
-    powerThemeName = `${coName}-cop`; // CHANGED: Use powerThemeName instead of coName
+    powerThemeName = `${coName}-cop`;
   } else {
     const powerSuffix = themeType === ThemeType.CO_POWER ? "-co-power" : "-super-co-power";
-    powerThemeName = isBlackHoleCO(coName) ? "bh" : "ally"; // CHANGED: Use powerThemeName instead of coName
-    powerThemeName += powerSuffix; // CHANGED: Use powerThemeName instead of coName
+    powerThemeName = isBlackHoleCO(coName) ? "bh" : "ally";
+    powerThemeName += powerSuffix;
   }
-  const hasCopIntro = hasIntroTheme(powerThemeName, actualGameType); // CHANGED: Use powerThemeName instead of coName
-  const hasCopPreloop = hasPreloopTheme(powerThemeName, actualGameType); // CHANGED: Use powerThemeName instead of coName
-  return hasCopIntro ? `t-${powerThemeName}-intro` : hasCopPreloop ? `t-${powerThemeName}-preloop` : `t-${powerThemeName}`; // CHANGED: Use powerThemeName instead of coName
+  const hasCopIntro = hasIntroTheme(powerThemeName, actualGameType);
+  const hasCopPreloop = hasPreloopTheme(powerThemeName, actualGameType);
+  return hasCopIntro ? `t-${powerThemeName}-intro` : hasCopPreloop ? `t-${powerThemeName}-preloop` : `t-${powerThemeName}`;
 }
 
 /**


### PR DESCRIPTION
Fixed getMusicFilename function to use complete power theme names (e.g., "bh-co-power") instead of falling back to incomplete names (e.g., "bh") when Black Hole COs activate their powers, preventing 404 errors when trying to load non-existent music files (e.g., `GET https://awbw-devj.duckdns.org/music/aw2/t-bh.ogg 404 (Not Found)`)

Currently running fix on [AWBWBattleground](https://www.twitch.tv/awbwbattleground) will see if it causes any other issues but seems to be working.