### PR TITLE
Update restartTheme condition for seamless loops

### DIFF
--- a/music_player/handlers.ts
+++ b/music_player/handlers.ts
@@ -246,7 +246,7 @@ function refreshMusicForNextTurn(playDelayMS = 0) {
 
   const refreshMusic = () => {
     musicSettings.themeType = getCurrentThemeType();
-    if (!musicSettings.seamlessLoopsInMirrors) restartTheme();
+    if (!musicSettings.seamlessLoopsInMirrors && !hasGameEnded()) restartTheme(); 
     if (musicSettings.playIntroEveryTurn) {
       specialIntroMap.clear();
     } else {


### PR DESCRIPTION
Fixes bug where end of game music sometimes restarts/plays twice.